### PR TITLE
Add `fof/gamification` as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "type": "flarum-extension",
     "license": "MIT",
     "require": {
-        "flarum/core": "^1.2.0"
+        "flarum/core": "^1.2.0",
+        "fof/gamification": "*"
     },
     "authors": [
         {


### PR DESCRIPTION
Since this extension depends on the `hotness` filter which is available only in the FoF Gamification extension, I think that it makes sense to include it as a dependency, so that this extension can't be installed or enabled in the admin panel before that extension is enabled.